### PR TITLE
Example loading dynamic routes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,11 +4,12 @@ import { HomeComponent } from './home/home.component';
 
 const routes: Routes = [
   {
+    pathMatch: 'full',
     path: '',
     component: HomeComponent
   },
   {
-    path: 'dashboard',
+    path: 'modules/dashboard',
     loadChildren: 'app/dashboard/dashboard.module#DashboardModule'
   }
 ];

--- a/src/app/app-routing.service.ts
+++ b/src/app/app-routing.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, NgModule } from '@angular/core';
+
+import { Http } from '@angular/http';
+import { Router } from '@angular/router';
+
+@Injectable()
+export class AppRoutingService {
+  private url = 'assets/data.json';
+
+  constructor(
+    private http: Http,
+    private router: Router
+  ) { }
+
+  getRoutes() {
+    const routerConfig = this.router.config;
+    this.http.get(this.url).subscribe((items) => {
+      routerConfig.push({
+        path: 'dashboard',
+        loadChildren: 'app/dashboard/dashboard.module#DashboardModule'
+      });
+      console.log('getRoutes', routerConfig);
+      this.router.resetConfig(routerConfig);
+    });
+  }
+}

--- a/src/app/app-routing.service.ts
+++ b/src/app/app-routing.service.ts
@@ -15,9 +15,9 @@ export class AppRoutingService {
   getRoutes() {
     const routerConfig = this.router.config;
     this.http.get(this.url).subscribe((items) => {
-      routerConfig.push({
-        path: 'dashboard',
-        loadChildren: 'app/dashboard/dashboard.module#DashboardModule'
+      const routes = items.json();
+      routes.forEach(route => {
+        routerConfig.push(route);
       });
       console.log('getRoutes', routerConfig);
       this.router.resetConfig(routerConfig);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,9 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { HttpModule } from '@angular/http';
 
 import { AppRoutingModule } from './app-routing.module';
+import { AppRoutingService } from './app-routing.service';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 
@@ -12,9 +14,14 @@ import { HomeComponent } from './home/home.component';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    HttpModule
   ],
-  providers: [],
+  providers: [AppRoutingService],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+  constructor (private routeService: AppRoutingService) {
+    routeService.getRoutes();
+  }
+}

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "dashboard",
+    "loadChildren": "app/dashboard/dashboard.module#DashboardModule"
+  }
+]


### PR DESCRIPTION
I thought this would be a useful extension to your article, showing how you can load dynamic routes from a json file or API.

The only caveat is that you have to declare the module as a route in code beforehand, so that Angular knows to create a js bundle for that module.

I have used the path 'modules/modulename' to hold lazy modules placeholders, but then the dynamic json loaded defines the actual routes, using the same modules.